### PR TITLE
Fix permissions on pwmchip (#8)

### DIFF
--- a/meta-iris/recipes-core/iris-utils/files/irisinit-ti
+++ b/meta-iris/recipes-core/iris-utils/files/irisinit-ti
@@ -106,8 +106,8 @@ echo Done with gpio setup
 echo Setup buzzer pwm
 cd /sys/class/pwm/pwmchip0
 echo 1 > export
-chmod o+x pwm1
 chmod 0666 -R pwm1
+chmod o+x pwm1
 cd pwm1
 echo 0 > enable
 ln -s /sys/class/pwm/pwmchip0/pwm1/period /tmp/io/pwmPeriod

--- a/meta-iris/recipes-core/iris-utils/files/irisinit-ti
+++ b/meta-iris/recipes-core/iris-utils/files/irisinit-ti
@@ -106,6 +106,7 @@ echo Done with gpio setup
 echo Setup buzzer pwm
 cd /sys/class/pwm/pwmchip0
 echo 1 > export
+chmod o+x pwm1
 chmod 0666 -R pwm1
 cd pwm1
 echo 0 > enable


### PR DESCRIPTION
(I think this only comes up on the yocto 2.7 upgrade, but it should apply cleanly to master without issue) 